### PR TITLE
Accept source agreements when executing 'winget list'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,3 +115,6 @@ WinDebloat
 ## Icons
 
 [Elephant](https://thenounproject.com/icon/elephant-face-1557798/) designed by [Icons Producer](https://thenounproject.com/iconsproducer/) from [The Noun Project](https://thenounproject.com).
+
+## Testing
+Unit tests should be run with elevated privileges

--- a/src/Tests/WinGetTests.cs
+++ b/src/Tests/WinGetTests.cs
@@ -43,4 +43,12 @@ public class WinGetTests
         list = await WinGet.List();
         Assert.IsFalse(list.Any(_ => _.Name == name));
     }
+
+    [Test]
+    [NonParallelizable]
+    public async Task ListAndAcceptSourceAgreements()
+    {
+        await WinGet.ResetSources();
+        await WinGet.List(); // This should not throw
+    }
 }

--- a/src/WinDebloat/WinGet.cs
+++ b/src/WinDebloat/WinGet.cs
@@ -50,7 +50,7 @@ public static class WinGet
 
     public static async Task<List<Package>> List()
     {
-        var result = await Run("list");
+        var result = await Run("list --accept-source-agreements");
 
         if (result.ExitCode != 0)
         {

--- a/src/WinDebloat/WinGet.cs
+++ b/src/WinDebloat/WinGet.cs
@@ -71,6 +71,17 @@ public static class WinGet
         return list;
     }
 
+    public static async Task ResetSources()
+    {
+        var arguments = "source reset --force";
+        var result = await Run(arguments);
+        
+        if (result.ExitCode != 0)
+        {
+            Throw(arguments, result);
+        }
+    }
+
     static void Throw(string arguments, RunResult result)
     {
         throw new(

--- a/src/WinDebloat/WinGet.cs
+++ b/src/WinDebloat/WinGet.cs
@@ -63,8 +63,8 @@ public static class WinGet
             if (line.Length > 35)
             {
                 list.Add(new(
-                    line[..35].TrimEnd(),
-                    line[36..73].TrimEnd()));
+                    line[..35].Trim(),
+                    line[36..73].Trim()));
             }
         }
 


### PR DESCRIPTION
This allows the tool to work if the user has never run winget list before.