### PR TITLE
Fix winget version parsing logic

### DIFF
--- a/src/Tests/SafeVersionTests.cs
+++ b/src/Tests/SafeVersionTests.cs
@@ -1,0 +1,19 @@
+﻿namespace Tests;
+
+public class VersionExtensionsTests
+{
+    private static IEnumerable<TestCaseData> GetVersionTestData()
+    {
+        yield return new("v1.2.3", new Version(1, 2, 3));
+        yield return new("v1.2.3.4", new Version(1, 2, 3, 4));
+        yield return new("v1.2.3-prerelease", new Version(1, 2, 3));
+        yield return new("v1.2.3.4-prerelease", new Version(1, 2, 3, 4));
+    }
+
+    [TestCaseSource(nameof(GetVersionTestData))]
+    public void VersionParse(string input, Version expected)
+    {
+        var actual = SafeVersion.Parse(input);
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/src/WinDebloat/SafeVersion.cs
+++ b/src/WinDebloat/SafeVersion.cs
@@ -1,0 +1,11 @@
+﻿public static class SafeVersion
+{
+    public static Version Parse(string version)
+    {
+        var hasPrereleaseTag = version.IndexOf('-');
+
+        return Version.Parse(hasPrereleaseTag != -1
+            ? version[1..hasPrereleaseTag]
+            : version[1..]);
+    }
+}

--- a/src/WinDebloat/WinGet.cs
+++ b/src/WinDebloat/WinGet.cs
@@ -118,7 +118,7 @@ public static class WinGet
             Throw(arguments, result);
         }
 
-        return Version.Parse(result.Output[0][1..]);
+        return SafeVersion.Parse(result.Output[0]);
     }
 
     [DoesNotReturn]


### PR DESCRIPTION
Winget follows semver versioning so if the target system has a preview or canary build installed say "1.5.2782-preview" System.Version will fallover (https://github.com/dotnet/runtime/issues/19317)

To handle this scenario just drop the prerelease tags from the semver version tag. The prerelease tag isn't really important for WinDebloat to enforce a min version.

![image](https://github.com/SimonCropp/WinDebloat/assets/2031163/7eb1e38d-6519-41c2-b350-c06f14c28407)
